### PR TITLE
Disabling debug mode for GCM-XMPP

### DIFF
--- a/server-netty/src/main/java/org/jboss/aerogear/sync/GcmHandler.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/sync/GcmHandler.java
@@ -65,7 +65,7 @@ public class GcmHandler extends ChannelHandlerAdapter {
         config.setSecurityMode(ConnectionConfiguration.SecurityMode.enabled);
         config.setReconnectionAllowed(true);
         config.setRosterLoadedAtLogin(false);
-        config.setDebuggerEnabled(true);
+        config.setDebuggerEnabled(false);
         config.setSendPresence(false);
         config.setSocketFactory(SSLSocketFactory.getDefault());
 


### PR DESCRIPTION
Disables the debug window by default.  This lets it run in docker