### PR TITLE
Clean up javadoc for aerogear-sync-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,43 @@ This is checksum for the shadow document on the opposing side.
 The format of diffs depends on the type of document/object type that the server supports. In the above example the type 
 that the server stores is JsonNode instance, and the format of patches is of JSON Patch format. For more information 
 about the various type, please refer to the different [synchronizers](./synchronizers).
+
+## SyncServerEngine
+The [SyncServerEngine](./server/server-core/src/main/java/org/jboss/aerogear/sync/server/ServerSyncEngine.java) is
+responsible for driving the main differential synchronization algorithm but leaves the details of how data is stored and how diffs/patches are processed on that data to injectable
+implementations.
+It does this by getting injected during [construction](./server/server-core/src/main/java/org/jboss/aerogear/sync/server/ServerSyncEngine.java#L46) with an instance of a _ServerSynchronizer_ and a _ServerDataStore_.
+
+### ServerDataStore
+The [ServerDataStore](./api/src/main/java/org/jboss/aerogear/sync/server/ServerDataStore.java) defines the methods for
+storing a specific document types.
+
+### ServerSynchronizer
+The [ServerSynchronizer](./api/src/main/java/org/jboss/aerogear/sync/server/ServerSynchronizer.java) defines the methods
+required to perform the specific diff/patch processing on the data type supported.
+
+#### Example of constructing a SyncServerEngine
+To construct a server that uses the JSON Patch [synchronizer](./synchronizers/json-patch) you would use the following code:
+
+    final JsonPatchServerSynchronizer synchronizer = new JsonPatchServerSynchronizer();
+    final ServerInMemoryDataStore<JsonNode, JsonPatchEdit> dataStore = new ServerInMemoryDataStore<JsonNode, JsonPatchEdit>();
+    final ServerSyncEngine<JsonNode, JsonPatchEdit> syncEngine = new ServerSyncEngine<JsonNode, JsonPatchEdit>(synchronizer, dataStore);
+
+### Synchronizers
+A _synchronizer_ in AeroGear is a module that serves two purposes which are closely related.
+One, is to provide storage for the data type, and the second is to provide the patching algorithm to be used on that data type.
+The name _synchronizer_ is because they take care of the synchronization part of the Differential Synchronization algorithm
+
+For example, one synchronizer might support plain text while another supports JSON Objects as the content of documents being stored. But a patching algorithm used for plain text might
+not be appropriate for JSON Objects. Hence the server and client side components are made up of "pluggable" [synchronizers](./synchronizers) and data stores implementations.
+
+By implementing the _ServerDataStore_ and _ServerSynchronizer_ interfaces different data formats and diff/patching algoritms can be provided. The AeroGear project provides the following
+[synchronizers](./synchronizers/json-patch) out of the box:
+
+*  [DiffMatchPatch](./synchronizers/diffmatchpatch)
+This synchronizer uses plain strings the document data type and Neil Frasers DiffMatchPatch Java implementation
+for its patching algorithm.
+
+*  [JSON Patch](./synchronizers/json-patch)
+This synchronizer uses [Jackson's](http://wiki.fasterxml.com/JacksonHome) _JsonNode_ as the document data type and uses
+[JSON PATCH](https://tools.ietf.org/html/rfc6902) for its patching algorithm.

--- a/api/src/main/java/org/jboss/aerogear/sync/DataStore.java
+++ b/api/src/main/java/org/jboss/aerogear/sync/DataStore.java
@@ -22,7 +22,8 @@ import java.util.Queue;
  * A DataStore implementation is responible for storing and serving data for a
  * Differential Synchronization implementation.
  *
- * @param <T> The type of the Document that this data store can handle.
+ * @param <T> The type of the Document that this data store can store.
+ * @param <S> The type of {@link Edit}s that this data store can store
  */
 public interface DataStore<T, S extends Edit<? extends Diff>> {
 

--- a/api/src/main/java/org/jboss/aerogear/sync/DataStore.java
+++ b/api/src/main/java/org/jboss/aerogear/sync/DataStore.java
@@ -19,7 +19,7 @@ package org.jboss.aerogear.sync;
 import java.util.Queue;
 
 /**
- * A DataStore implementation is responible for storing and serving data for a
+ * A DataStore implementation is responsible for storing and serving data for a
  * Differential Synchronization implementation.
  *
  * @param <T> The type of the Document that this data store can store.

--- a/api/src/main/java/org/jboss/aerogear/sync/Diff.java
+++ b/api/src/main/java/org/jboss/aerogear/sync/Diff.java
@@ -22,7 +22,7 @@ import org.jboss.aerogear.sync.server.ServerSynchronizer;
 /**
  * A marker interface that represents a diff or two versions of a document/object.
  * <p>
- * The actual implementation of a diff will vary depending on the type of content the the
+ * The actual implementation of a diff will vary depending on the type of content the
  * {@link ClientSynchronizer} or {@link ServerSynchronizer} can handle.
  */
 public interface Diff {

--- a/api/src/main/java/org/jboss/aerogear/sync/PatchMessage.java
+++ b/api/src/main/java/org/jboss/aerogear/sync/PatchMessage.java
@@ -19,7 +19,12 @@ package org.jboss.aerogear.sync;
 import java.util.Queue;
 
 /**
- * Represents a stack of edits.
+ * Represents a stack of changes made on the server of client side.
+ * <p>
+ * A PatchMessage is what is passed between the client and the server. It contains a Queue of
+ * {@link Edit}s that represent updates to be performed on the opposing sides document.
+ *
+ * @param <T> The type of the {@link Edit} that this PatchMessage holds
  */
 public interface PatchMessage<T extends Edit<? extends Diff>> extends Payload<PatchMessage<T>> {
 

--- a/api/src/main/java/org/jboss/aerogear/sync/Payload.java
+++ b/api/src/main/java/org/jboss/aerogear/sync/Payload.java
@@ -16,10 +16,26 @@
  */
 package org.jboss.aerogear.sync;
 
+/**
+ * Represents something that can be exchanged in JSON format.
+ *
+ * @param <T> the type of the payload
+ */
 public interface Payload<T> {
 
+    /**
+     * Transforms this payload to a JSON String representation.
+     *
+     * @return {@code String} the payload as a JSON String representation
+     */
     String asJson();
 
+    /**
+     * Transforms the passed in {@code String} JSON representation into this payloads type.
+     *
+     * @param json a string representation of this payloads type
+     * @return {@code T} an instance of this payloads type
+     */
     T fromJson(String json);
 
 }

--- a/api/src/main/java/org/jboss/aerogear/sync/ShadowDocument.java
+++ b/api/src/main/java/org/jboss/aerogear/sync/ShadowDocument.java
@@ -18,10 +18,8 @@ package org.jboss.aerogear.sync;
 
 /**
  * A shadow document for each client will exist on the client side and also on the server side.
- *
- * A shadow document is update after a successful patch/merge as been performed. A patch/merge
- * is done with specific versions on the client and server document which are stored by instances
- * of this class.
+ * <p>
+ * A shadow document is updated after a successful patch has been performed.
  *
  * @param <T> The type of the Document that this instance shadows.
  */

--- a/api/src/main/java/org/jboss/aerogear/sync/client/package-info.java
+++ b/api/src/main/java/org/jboss/aerogear/sync/client/package-info.java
@@ -14,16 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
-
-import org.jboss.aerogear.sync.client.ClientSynchronizer;
-import org.jboss.aerogear.sync.server.ServerSynchronizer;
 
 /**
- * A marker interface that represents a diff or two versions of a document/object.
- * <p>
- * The actual implementation of a diff will vary depending on the type of content the the
- * {@link ClientSynchronizer} or {@link ServerSynchronizer} can handle.
+ * This package contains interfaces for AeroGear Sync Client API.
  */
-public interface Diff {
-}
+package org.jboss.aerogear.sync.client;

--- a/api/src/main/java/org/jboss/aerogear/sync/package-info.java
+++ b/api/src/main/java/org/jboss/aerogear/sync/package-info.java
@@ -14,16 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
-
-import org.jboss.aerogear.sync.client.ClientSynchronizer;
-import org.jboss.aerogear.sync.server.ServerSynchronizer;
 
 /**
- * A marker interface that represents a diff or two versions of a document/object.
+ * This package contains interfaces for AeroGear Sync.
  * <p>
- * The actual implementation of a diff will vary depending on the type of content the the
- * {@link ClientSynchronizer} or {@link ServerSynchronizer} can handle.
+ * The interfaces in this package are shared among both server and client implementations.
+ *
+ * @see org.jboss.aerogear.sync.client
+ * @see org.jboss.aerogear.sync.server
  */
-public interface Diff {
-}
+package org.jboss.aerogear.sync;

--- a/api/src/main/java/org/jboss/aerogear/sync/server/package-info.java
+++ b/api/src/main/java/org/jboss/aerogear/sync/server/package-info.java
@@ -14,16 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
-
-import org.jboss.aerogear.sync.client.ClientSynchronizer;
-import org.jboss.aerogear.sync.server.ServerSynchronizer;
 
 /**
- * A marker interface that represents a diff or two versions of a document/object.
- * <p>
- * The actual implementation of a diff will vary depending on the type of content the the
- * {@link ClientSynchronizer} or {@link ServerSynchronizer} can handle.
+ * This package contains interfaces for AeroGear Sync Server API.
  */
-public interface Diff {
-}
+package org.jboss.aerogear.sync.server;

--- a/client/client-core/src/main/java/org/jboss/aerogear/sync/client/ClientInMemoryDataStore.java
+++ b/client/client-core/src/main/java/org/jboss/aerogear/sync/client/ClientInMemoryDataStore.java
@@ -29,6 +29,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 
+/**
+ * An in-memory implementation of {@link ClientDataStore}.
+ * <p>
+ * This implementation is mainly intended for testing and example applications.
+ *
+ * @param <T> The data type data that this implementation can handle.
+ * @param <S> The type of {@link Edit}s that this implementation can handle.
+ */
 public class ClientInMemoryDataStore<T, S extends Edit<? extends Diff>> implements ClientDataStore<T, S> {
 
     private final Queue<S> emptyQueue = new LinkedList<S>();

--- a/client/client-core/src/main/java/org/jboss/aerogear/sync/client/ClientSyncEngine.java
+++ b/client/client-core/src/main/java/org/jboss/aerogear/sync/client/ClientSyncEngine.java
@@ -32,10 +32,32 @@ import java.util.Iterator;
 import java.util.Observable;
 import java.util.Queue;
 
+
 /**
- * The client side of the differential synchronization implementation.
+ * The ClientSyncEngine is responsible for driving client side of the differential synchronization algorithm.
+ * <p>
+ * During construction the engine gets injected with an instance of {@link ClientSynchronizer}
+ * which takes care of diff/patching operations, and an instance of {@link ClientDataStore} for
+ * storing data.
+ * <p>
+ * A synchronizer in AeroGear is a module that serves two purposes which are closely related. One, is to provide
+ * storage for the data type, and the second is to provide the patching algorithm to be used on that data type.
+ * The name synchronizer is because they take care of the synchronization part of the Differential Synchronization
+ * algorithm. For example, one synchronizer might support plain text while another supports JSON Objects as the
+ * content of documents being stored. But a patching algorithm used for plain text might not be appropriate for JSON
+ * Objects.
+ * <p>
  *
- * @param <T> The type of document that this implementation can handle.
+ * To construct a server that uses the JSON Patch you would use the following code:
+ * <pre>
+ * {@code
+ * final JsonPatchServerSynchronizer synchronizer = new JsonPatchServerSynchronizer();
+ * final ClientInMemoryDataStore<JsonNode, JsonPatchEdit> dataStore = new ClientInMemoryDataStore<JsonNode, JsonPatchEdit>();
+ * final ClientSyncEngine<JsonNode, JsonPatchEdit> syncEngine = new ClientSyncEngine<JsonNode, JsonPatchEdit>(synchronizer, dataStore);
+ * }</pre>
+ *
+ * @param <T> The data type data that this implementation can handle.
+ * @param <S> The type of {@link Edit}s that this implementation can handle.
  */
 public class ClientSyncEngine<T, S extends Edit<? extends Diff>> extends Observable {
 

--- a/client/client-core/src/test/java/org/jboss/aerogear/sync/client/ClientSyncEngineTest.java
+++ b/client/client-core/src/test/java/org/jboss/aerogear/sync/client/ClientSyncEngineTest.java
@@ -21,7 +21,7 @@ import org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchDiff;
 import org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchDiff.Operation;
 import org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchEdit;
 import org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchMessage;
-import org.jboss.aerogear.sync.diffmatchpatch.client.DefaultClientSynchronizer;
+import org.jboss.aerogear.sync.diffmatchpatch.client.DiffMatchPatchClientSynchronizer;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,7 +41,7 @@ public class ClientSyncEngineTest {
     @Before
     public void setup() {
         dataStore = new ClientInMemoryDataStore<String, DiffMatchPatchEdit>();
-        engine = new ClientSyncEngine<String, DiffMatchPatchEdit>(new DefaultClientSynchronizer(), dataStore);
+        engine = new ClientSyncEngine<String, DiffMatchPatchEdit>(new DiffMatchPatchClientSynchronizer(), dataStore);
     }
 
     @Test

--- a/client/client-netty/src/main/java/org/jboss/aerogear/sync/DiffSyncClient.java
+++ b/client/client-netty/src/main/java/org/jboss/aerogear/sync/DiffSyncClient.java
@@ -41,7 +41,10 @@ import java.util.Observable;
 import java.util.Observer;
 
 /**
- * A Netty based WebSocket client that is able to handle differential synchronization edits.
+ * A Netty based WebSocket client for AeroGear Diff Sync Server.
+ *
+ * @param <T> The type of the Document that this client can handle
+ * @param <S> The type of {@link Edit}s that this client can handle
  */
 public final class DiffSyncClient<T, S extends Edit<? extends Diff>> extends Observable {
 

--- a/client/client-netty/src/main/java/org/jboss/aerogear/sync/DiffSyncClientHandler.java
+++ b/client/client-netty/src/main/java/org/jboss/aerogear/sync/DiffSyncClientHandler.java
@@ -28,6 +28,14 @@ import org.jboss.aerogear.sync.server.MessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A Netty handler for {@link WebSocketFrame}s.
+ * <p>
+ * This handle takes care of the client side message processing for AeroGear Sync Server.
+ *
+ * @param <T> The type of the Document that this handler handles
+ * @param <S> The type of {@link Edit}s that this handler handles
+ */
 public class DiffSyncClientHandler<T, S extends Edit<? extends Diff>> extends SimpleChannelInboundHandler<WebSocketFrame> {
 
     private static final Logger logger = LoggerFactory.getLogger(DiffSyncClientHandler.class);

--- a/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/DiffSyncClient.java
+++ b/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/DiffSyncClient.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.client.netty;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
@@ -31,9 +31,13 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
+import org.jboss.aerogear.sync.ClientDocument;
+import org.jboss.aerogear.sync.Diff;
+import org.jboss.aerogear.sync.Edit;
+import org.jboss.aerogear.sync.PatchMessage;
 import org.jboss.aerogear.sync.client.ClientInMemoryDataStore;
 import org.jboss.aerogear.sync.client.ClientSyncEngine;
-import org.jboss.aerogear.sync.diffmatchpatch.client.DefaultClientSynchronizer;
+import org.jboss.aerogear.sync.diffmatchpatch.client.DiffMatchPatchClientSynchronizer;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -179,7 +183,7 @@ public final class DiffSyncClient<T, S extends Edit<? extends Diff>> extends Obs
         
         public DiffSyncClient<T, S> build() {
             if (engine == null) {
-                engine = new ClientSyncEngine(new DefaultClientSynchronizer(), new ClientInMemoryDataStore());
+                engine = new ClientSyncEngine(new DiffMatchPatchClientSynchronizer(), new ClientInMemoryDataStore());
             }
             uri = parseUri(this);
             return new DiffSyncClient<T, S>(this);

--- a/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/DiffSyncClientHandler.java
+++ b/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/DiffSyncClientHandler.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.client.netty;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.channel.ChannelHandlerContext;
@@ -22,6 +22,9 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import org.jboss.aerogear.sync.Diff;
+import org.jboss.aerogear.sync.Edit;
+import org.jboss.aerogear.sync.PatchMessage;
 import org.jboss.aerogear.sync.client.ClientSyncEngine;
 import org.jboss.aerogear.sync.diffmatchpatch.JsonMapper;
 import org.jboss.aerogear.sync.server.MessageType;

--- a/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/WebSocketClientHandler.java
+++ b/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/WebSocketClientHandler.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.client.netty;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;

--- a/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/package-info.java
+++ b/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains Netty Client for AeroGear Sync.
+ *
+ * @see org.jboss.aerogear.sync.client.netty.DiffSyncClient
+ */
+package org.jboss.aerogear.sync.client.netty;

--- a/client/client-netty/src/test/java/org/jboss/aerogear/sync/client/netty/DiffSyncClientIntegrationTest.java
+++ b/client/client-netty/src/test/java/org/jboss/aerogear/sync/client/netty/DiffSyncClientIntegrationTest.java
@@ -14,9 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.client.netty;
 
+import org.jboss.aerogear.sync.ClientDocument;
+import org.jboss.aerogear.sync.DefaultClientDocument;
 import org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchEdit;
+import org.jboss.aerogear.sync.client.netty.DiffSyncClient;
 import org.junit.Test;
 
 public class DiffSyncClientIntegrationTest {

--- a/client/client-netty/src/test/java/org/jboss/aerogear/sync/client/netty/JsonPatchClientIntegrationTest.java
+++ b/client/client-netty/src/test/java/org/jboss/aerogear/sync/client/netty/JsonPatchClientIntegrationTest.java
@@ -14,14 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.client.netty;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.jboss.aerogear.sync.ClientDocument;
+import org.jboss.aerogear.sync.DefaultClientDocument;
 import org.jboss.aerogear.sync.client.ClientInMemoryDataStore;
 import org.jboss.aerogear.sync.client.ClientSyncEngine;
-import org.jboss.aerogear.sync.jsonpatch.JsonPatchClientSynchronizer;
+import org.jboss.aerogear.sync.jsonpatch.client.JsonPatchClientSynchronizer;
 import org.jboss.aerogear.sync.jsonpatch.JsonPatchEdit;
 import org.junit.Test;
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -40,7 +40,7 @@
                 </descriptors>
                 <archive>
                   <manifest>
-                    <mainClass>org.jboss.aerogear.sync.JsonMergePatchSyncServer</mainClass>
+                    <mainClass>org.jboss.aerogear.sync.server.netty.JsonMergePatchSyncServer</mainClass>
                     <addClasspath>true</addClasspath>
                   </manifest>
                 </archive>

--- a/itests/src/test/java/org/jboss/aerogear/sync/client/ClientSyncEngineIntegrationTest.java
+++ b/itests/src/test/java/org/jboss/aerogear/sync/client/ClientSyncEngineIntegrationTest.java
@@ -25,8 +25,8 @@ import org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchDiff;
 import org.jboss.aerogear.sync.Document;
 import org.jboss.aerogear.sync.PatchMessage;
 import org.jboss.aerogear.sync.ShadowDocument;
+import org.jboss.aerogear.sync.diffmatchpatch.client.DiffMatchPatchClientSynchronizer;
 import org.jboss.aerogear.sync.diffmatchpatch.server.DiffMatchPatchServerSynchronizer;
-import org.jboss.aerogear.sync.diffmatchpatch.client.DefaultClientSynchronizer;
 import org.jboss.aerogear.sync.server.ServerInMemoryDataStore;
 import org.jboss.aerogear.sync.server.ServerSyncEngine;
 import org.jboss.aerogear.sync.server.Subscriber;
@@ -52,7 +52,7 @@ public class ClientSyncEngineIntegrationTest {
     @Before
     public void setup() {
         dataStore = new ClientInMemoryDataStore<String, DiffMatchPatchEdit>();
-        clientSyncEngine = new ClientSyncEngine<String, DiffMatchPatchEdit>(new DefaultClientSynchronizer(), dataStore);
+        clientSyncEngine = new ClientSyncEngine<String, DiffMatchPatchEdit>(new DiffMatchPatchClientSynchronizer(), dataStore);
         serverSyncEngine = new ServerSyncEngine<String, DiffMatchPatchEdit>(new DiffMatchPatchServerSynchronizer(), new ServerInMemoryDataStore<String, DiffMatchPatchEdit>());
     }
 

--- a/itests/src/test/java/org/jboss/aerogear/sync/server/ServerSyncEngineIntegrationTest.java
+++ b/itests/src/test/java/org/jboss/aerogear/sync/server/ServerSyncEngineIntegrationTest.java
@@ -28,7 +28,7 @@ import org.jboss.aerogear.sync.ShadowDocument;
 import org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchDiff.Operation;
 import org.jboss.aerogear.sync.client.ClientDataStore;
 import org.jboss.aerogear.sync.client.ClientSyncEngine;
-import org.jboss.aerogear.sync.diffmatchpatch.client.DefaultClientSynchronizer;
+import org.jboss.aerogear.sync.diffmatchpatch.client.DiffMatchPatchClientSynchronizer;
 import org.jboss.aerogear.sync.diffmatchpatch.server.DiffMatchPatchServerSynchronizer;
 import org.junit.Before;
 import org.junit.Test;
@@ -194,7 +194,7 @@ public class ServerSyncEngineIntegrationTest {
 
     private static ClientSyncEngine<String, DiffMatchPatchEdit> clientSyncEngine() {
         final ClientDataStore<String, DiffMatchPatchEdit> clientDataStore = new ClientInMemoryDataStore<String, DiffMatchPatchEdit>();
-        return new ClientSyncEngine<String, DiffMatchPatchEdit>(new DefaultClientSynchronizer(), clientDataStore);
+        return new ClientSyncEngine<String, DiffMatchPatchEdit>(new DiffMatchPatchClientSynchronizer(), clientDataStore);
     }
 
     private static DefaultDocument<String> newDoc(final String documentId, String content) {

--- a/server/server-core/README.md
+++ b/server/server-core/README.md
@@ -1,26 +1,44 @@
 ## AeroGear Server Differential Synchronization Server Core
 This module contains implementations for the [server side API](../api)
 
-### ServerSyncEngine
-The [ServerSyncEngine](./src/main/java/org/jboss/aerogear/sync/server/ServerSyncEngine.java) is the class that drives
-the server side. This is the class that a server implementation would use by [adding documents](./src/main/java/org/jboss/aerogear/sync/server/ServerSyncEngine.java#L53)
-to the engine, and then later to have the engine [generate edits](./src/main/java/org/jboss/aerogear/sync/server/ServerSyncEngine.java#L89)
-that can be sent to the server side for processing. The engine also handles the revers, that is when edits are recieved
-from the server they are processed by the engines [patch](./src/main/java/org/jboss/aerogear/sync/server/ServerSyncEngine.java#L101)
-method.
+## SyncServerEngine
+The [SyncServerEngine](./server-core/src/main/java/org/jboss/aerogear/sync/server/ServerSyncEngine.java) is
+responsible for driving the main differential synchronization algorithm but leaves the details of how data is stored and how diffs/patches are processed on that data to injectable
+implementations.
+It does this by getting injected during [construction](./server-core/src/main/java/org/jboss/aerogear/sync/server/ServerSyncEngine.java#L46) with an instance of a _ServerSynchronizer_ and a _ServerDataStore_.
 
-When the server engine is created it is passed an implementation of [ServerSynchronizer](../api/src/main/java/org/jboss/aerogear/sync/server/ServerSynchronizer.java)
- , and [ServerDataStore](../api/src/main/java/org/jboss/aerogear/sync/server/ServerDataStore.java) which allows for
- changing the underlying synchronization algorithm and the storage implementation respectively.
+### ServerDataStore
+The [ServerDataStore](../../api/src/main/java/org/jboss/aerogear/sync/server/ServerDataStore.java) defines the methods for
+storing a specific document types.
 
-#### DefaultServerSynchronizer
-The [DefaultServerSynchronizer](./src/main/java/org/jboss/aerogear/sync/server/DefaultServerSynchronizer.java) is an
-implementation of [ServerSynchronizer](../api/src/main/java/org/jboss/aerogear/sync/server/ServerSynchronizer.java) that
-can handle text documents. It uses [google-diff-match-patch](https://code.google.com/p/google-diff-match-patch/) with some minor tweaks.
+### ServerSynchronizer
+The [ServerSynchronizer](./../api/src/main/java/org/jboss/aerogear/sync/server/ServerSynchronizer.java) defines the methods
+required to perform the specific diff/patch processing on the data type supported.
 
-#### ServerInMemoryDataStore
-The [ServerInMemoryDataStore](./src/main/java/org/jboss/aerogear/sync/server/ServerInMemoryDataStore.java) is an
-implementation of [ServerDataStore](../api/src/main/java/org/jboss/aerogear/sync/server/ServerDataStore.java) that
-storing all data in-memory.
+#### Example of constructing a SyncServerEngine
+To construct a server that uses the JSON Patch [synchronizer](./synchronizers/json-patch) you would use the following code:
+
+    final JsonPatchServerSynchronizer synchronizer = new JsonPatchServerSynchronizer();
+    final ServerInMemoryDataStore<JsonNode, JsonPatchEdit> dataStore = new ServerInMemoryDataStore<JsonNode, JsonPatchEdit>();
+    final ServerSyncEngine<JsonNode, JsonPatchEdit> syncEngine = new ServerSyncEngine<JsonNode, JsonPatchEdit>(synchronizer, dataStore);
+
+### Synchronizers
+A _synchronizer_ in AeroGear is a module that serves two purposes which are closely related.
+One, is to provide storage for the data type, and the second is to provide the patching algorithm to be used on that data type.
+The name _synchronizer_ is because they take care of the synchronization part of the Differential Synchronization algorithm
+
+For example, one synchronizer might support plain text while another supports JSON Objects as the content of documents being stored. But a patching algorithm used for plain text might
+not be appropriate for JSON Objects. Hence the server and client side components are made up of "pluggable" [synchronizers](../../synchronizers) and data stores implementations.
+
+By implementing the _ServerDataStore_ and _ServerSynchronizer_ interfaces different data formats and diff/patching algoritms can be provided. The AeroGear project provides the following
+[synchronizers](../..//synchronizers/json-patch) out of the box:
+
+*  [DiffMatchPatch](../../synchronizers/diffmatchpatch)
+This synchronizer uses plain strings the document data type and Neil Frasers DiffMatchPatch Java implementation
+for its patching algorithm.
+
+*  [JSON Patch](../../synchronizers/json-patch)
+This synchronizer uses [Jackson's](http://wiki.fasterxml.com/JacksonHome) _JsonNode_ as the document data type and uses
+[JSON PATCH](https://tools.ietf.org/html/rfc6902) for its patching algorithm.
 
 

--- a/server/server-core/src/main/java/org/jboss/aerogear/sync/server/ServerInMemoryDataStore.java
+++ b/server/server-core/src/main/java/org/jboss/aerogear/sync/server/ServerInMemoryDataStore.java
@@ -30,6 +30,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 
+/**
+ * An in-memory implementation of {@link ServerDataStore}.
+ * <p>
+ * This implementation is mainly intended for testing and example applications.
+ *
+ * @param <T> The data type data that this implementation can handle.
+ * @param <S> The type of {@link Edit}s that this implementation can handle.
+ */
 public class ServerInMemoryDataStore<T, S extends Edit<? extends Diff>> implements ServerDataStore<T, S> {
 
     private final Queue<S> emptyQueue = new LinkedList<S>();

--- a/server/server-core/src/main/java/org/jboss/aerogear/sync/server/ServerSyncEngine.java
+++ b/server/server-core/src/main/java/org/jboss/aerogear/sync/server/ServerSyncEngine.java
@@ -29,9 +29,30 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * The server side of the differential synchronization implementation.
+ * The ServerSyncEngine is responsible for driving the main differential synchronization algorithm.
+ * <p>
+ * During construction the engine gets injected with an instance of {@link ServerSynchronizer}
+ * which takes care of diff/patching operations, and an instance of {@link ServerDataStore} for
+ * storing data.
+ * <p>
+ * A synchronizer in AeroGear is a module that serves two purposes which are closely related. One, is to provide
+ * storage for the data type, and the second is to provide the patching algorithm to be used on that data type.
+ * The name synchronizer is because they take care of the synchronization part of the Differential Synchronization
+ * algorithm. For example, one synchronizer might support plain text while another supports JSON Objects as the
+ * content of documents being stored. But a patching algorithm used for plain text might not be appropriate for JSON
+ * Objects.
+ * <p>
  *
- * @param <T> The type of document that this implementation can handle.
+ * To construct a server that uses the JSON Patch you would use the following code:
+ * <pre>
+ * {@code
+ * final JsonPatchServerSynchronizer synchronizer = new JsonPatchServerSynchronizer();
+ * final ServerInMemoryDataStore<JsonNode, JsonPatchEdit> dataStore = new ServerInMemoryDataStore<JsonNode, JsonPatchEdit>();
+ * final ServerSyncEngine<JsonNode, JsonPatchEdit> syncEngine = new ServerSyncEngine<JsonNode, JsonPatchEdit>(synchronizer, dataStore);
+ * }</pre>
+ *
+ * @param <T> The data type data that this implementation can handle.
+ * @param <S> The type of {@link Edit}s that this implementation can handle.
  */
 public class ServerSyncEngine<T, S extends Edit<? extends Diff>> {
 
@@ -43,6 +64,12 @@ public class ServerSyncEngine<T, S extends Edit<? extends Diff>> {
     private final ServerSynchronizer<T, S> synchronizer;
     private final ServerDataStore<T, S> dataStore;
 
+    /**
+     * Sole constructor.
+     *
+     * @param synchronizer an instance of {@link ServerSynchronizer} that will take care for the diff/patching
+     * @param dataStore an instance of {@link ServerDataStore} to store the document/objects
+     */
     public ServerSyncEngine(final ServerSynchronizer<T, S> synchronizer, final ServerDataStore<T, S> dataStore) {
         this.synchronizer = synchronizer;
         this.dataStore = dataStore;

--- a/server/server-netty/pom.xml
+++ b/server/server-netty/pom.xml
@@ -95,7 +95,7 @@
                 <arguments>
                   <argument>-classpath</argument>
                   <classpath/>
-                  <argument>org.jboss.aerogear.sync.DiffMatchPatchSyncServer</argument>
+                  <argument>org.jboss.aerogear.sync.server.netty.DiffMatchPatchSyncServer</argument>
                 </arguments>
                 <classpathScope>compile</classpathScope>
                 <systemProperties>
@@ -122,7 +122,7 @@
                 <arguments>
                   <argument>-classpath</argument>
                   <classpath/>
-                  <argument>org.jboss.aerogear.sync.JsonPatchSyncServer</argument>
+                  <argument>org.jboss.aerogear.sync.server.netty.JsonPatchSyncServer</argument>
                 </arguments>
                 <classpathScope>compile</classpathScope>
                 <systemProperties>
@@ -149,7 +149,7 @@
                           <arguments>
                               <argument>-classpath</argument>
                               <classpath/>
-                              <argument>org.jboss.aerogear.sync.JsonMergePatchSyncServer</argument>
+                              <argument>org.jboss.aerogear.sync.server.netty.JsonMergePatchSyncServer</argument>
                           </arguments>
                           <classpathScope>compile</classpathScope>
                           <systemProperties>

--- a/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/ConfigReader.java
+++ b/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/ConfigReader.java
@@ -10,7 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.netty;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -20,7 +20,7 @@ import java.io.InputStream;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.jboss.aerogear.sync.StandaloneConfig.Builder;
+import org.jboss.aerogear.sync.server.netty.StandaloneConfig.Builder;
 
 /**
  * Utility to read a JSON config files.

--- a/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/DiffMatchPatchSyncServer.java
+++ b/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/DiffMatchPatchSyncServer.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.netty;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;

--- a/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/DiffSyncHandler.java
+++ b/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/DiffSyncHandler.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.netty;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.channel.ChannelFuture;
@@ -26,6 +26,10 @@ import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.util.AttributeKey;
+import org.jboss.aerogear.sync.Diff;
+import org.jboss.aerogear.sync.Document;
+import org.jboss.aerogear.sync.Edit;
+import org.jboss.aerogear.sync.PatchMessage;
 import org.jboss.aerogear.sync.diffmatchpatch.JsonMapper;
 import org.jboss.aerogear.sync.server.MessageType;
 import org.jboss.aerogear.sync.server.ServerSyncEngine;

--- a/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/GcmHandler.java
+++ b/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/GcmHandler.java
@@ -14,10 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.netty;
 
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
+import org.jboss.aerogear.sync.Diff;
+import org.jboss.aerogear.sync.Edit;
+import org.jboss.aerogear.sync.server.gcm.GcmDiffSyncHandler;
 import org.jboss.aerogear.sync.server.ServerSyncEngine;
 import org.jivesoftware.smack.ConnectionConfiguration;
 import org.jivesoftware.smack.ConnectionListener;

--- a/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/JsonMergePatchSyncServer.java
+++ b/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/JsonMergePatchSyncServer.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.netty;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.bootstrap.ServerBootstrap;

--- a/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/JsonPatchSyncServer.java
+++ b/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/JsonPatchSyncServer.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.netty;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.bootstrap.ServerBootstrap;

--- a/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/NettySubscriber.java
+++ b/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/NettySubscriber.java
@@ -14,10 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.netty;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.jboss.aerogear.sync.PatchMessage;
 import org.jboss.aerogear.sync.server.Subscriber;
 
 

--- a/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/StandaloneConfig.java
+++ b/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/StandaloneConfig.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.netty;
 
 public class StandaloneConfig {
 

--- a/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/package-info.java
+++ b/server/server-netty/src/main/java/org/jboss/aerogear/sync/server/netty/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains Netty Servers for AeroGear Sync.
+ *
+ * @see org.jboss.aerogear.sync.server.netty.DiffMatchPatchSyncServer
+ * @see org.jboss.aerogear.sync.server.netty.JsonPatchSyncServer
+ * @see org.jboss.aerogear.sync.server.netty.JsonMergePatchSyncServer
+ */
+package org.jboss.aerogear.sync.server.netty;

--- a/server/server-netty/src/test/java/org/jboss/aerogear/sync/server/netty/DiffSyncHandlerTest.java
+++ b/server/server-netty/src/test/java/org/jboss/aerogear/sync/server/netty/DiffSyncHandlerTest.java
@@ -14,19 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.netty;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.jboss.aerogear.sync.DefaultClientDocument;
+import org.jboss.aerogear.sync.PatchMessage;
 import org.jboss.aerogear.sync.client.ClientInMemoryDataStore;
 import org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchDiff.Operation;
 import org.jboss.aerogear.sync.client.ClientSyncEngine;
 import org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchEdit;
 import org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchMessage;
 import org.jboss.aerogear.sync.diffmatchpatch.JsonMapper;
-import org.jboss.aerogear.sync.diffmatchpatch.client.DefaultClientSynchronizer;
+import org.jboss.aerogear.sync.diffmatchpatch.client.DiffMatchPatchClientSynchronizer;
 import org.jboss.aerogear.sync.diffmatchpatch.server.DiffMatchPatchServerSynchronizer;
 import org.jboss.aerogear.sync.server.ServerInMemoryDataStore;
 import org.jboss.aerogear.sync.server.ServerSyncEngine;
@@ -541,7 +543,7 @@ public class DiffSyncHandlerTest {
     }
 
     private static ClientSyncEngine<String, DiffMatchPatchEdit> newClientSyncEngine() {
-        return new ClientSyncEngine<String, DiffMatchPatchEdit>(new DefaultClientSynchronizer(),
+        return new ClientSyncEngine<String, DiffMatchPatchEdit>(new DiffMatchPatchClientSynchronizer(),
                 new ClientInMemoryDataStore<String, DiffMatchPatchEdit>());
     }
 

--- a/server/server-xmpp/src/main/java/org/jboss/aerogear/sync/server/gcm/GcmDiffSyncHandler.java
+++ b/server/server-xmpp/src/main/java/org/jboss/aerogear/sync/server/gcm/GcmDiffSyncHandler.java
@@ -14,8 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.gcm;
 
+import org.jboss.aerogear.sync.Diff;
+import org.jboss.aerogear.sync.Document;
+import org.jboss.aerogear.sync.Edit;
+import org.jboss.aerogear.sync.PatchMessage;
 import org.jboss.aerogear.sync.diffmatchpatch.JsonMapper;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPConnection;
@@ -41,8 +45,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.jboss.aerogear.sync.server.MessageType;
 import org.jboss.aerogear.sync.server.ServerSyncEngine;
 import org.jivesoftware.smack.PacketListener;
-
-import static org.jboss.aerogear.sync.GcmMessages.createJsonMessage;
 
 public class GcmDiffSyncHandler<T, S extends Edit<? extends Diff>> implements PacketListener {
 
@@ -187,7 +189,7 @@ public class GcmDiffSyncHandler<T, S extends Edit<? extends Diff>> implements Pa
             case ADD:
                 final Document<T> doc = syncEngine.documentFromJson(syncMessage);
                 final PatchMessage<S> patchMessage = addSubscriber(doc, diffsyncClientId, googleRegistrationId);
-                send(createJsonMessage(googleRegistrationId, "m-" + UUID.randomUUID(), patchMessage.asJson()));
+                send(GcmMessages.createJsonMessage(googleRegistrationId, "m-" + UUID.randomUUID(), patchMessage.asJson()));
                 break;
             case PATCH:
                 final PatchMessage<S> clientPatchMessage = syncEngine.patchMessageFromJson(syncMessage.toString());

--- a/server/server-xmpp/src/main/java/org/jboss/aerogear/sync/server/gcm/GcmMessages.java
+++ b/server/server-xmpp/src/main/java/org/jboss/aerogear/sync/server/gcm/GcmMessages.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.gcm;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.jboss.aerogear.sync.diffmatchpatch.JsonMapper;

--- a/server/server-xmpp/src/main/java/org/jboss/aerogear/sync/server/gcm/GcmSubscriber.java
+++ b/server/server-xmpp/src/main/java/org/jboss/aerogear/sync/server/gcm/GcmSubscriber.java
@@ -14,9 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.server.gcm;
 
-import org.jboss.aerogear.sync.GcmDiffSyncHandler.GcmPacketExtension;
+import org.jboss.aerogear.sync.server.gcm.GcmDiffSyncHandler.GcmPacketExtension;
+import org.jboss.aerogear.sync.PatchMessage;
 import org.jboss.aerogear.sync.server.Subscriber;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPConnection;
@@ -26,7 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.UUID;
 
-import static org.jboss.aerogear.sync.GcmMessages.createJsonMessage;
+import static org.jboss.aerogear.sync.server.gcm.GcmMessages.createJsonMessage;
 
 public class GcmSubscriber implements Subscriber<XMPPConnection> {
 

--- a/server/server-xmpp/src/main/java/org/jboss/aerogear/sync/server/gcm/package-info.java
+++ b/server/server-xmpp/src/main/java/org/jboss/aerogear/sync/server/gcm/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains Google Cloud Messaging classes for usage with AeroGear Sync Server.
+ *
+ * @see org.jboss.aerogear.sync.server.gcm.GcmDiffSyncHandler
+ * @see org.jboss.aerogear.sync.server.gcm.GcmSubscriber
+ */
+package org.jboss.aerogear.sync.server.gcm;

--- a/synchronizers/diffmatchpatch/client/src/main/java/org/jboss/aerogear/sync/diffmatchpatch/client/DiffMatchPatchClientSynchronizer.java
+++ b/synchronizers/diffmatchpatch/client/src/main/java/org/jboss/aerogear/sync/diffmatchpatch/client/DiffMatchPatchClientSynchronizer.java
@@ -32,15 +32,15 @@ import java.util.Queue;
 /**
  * A {@link ClientSynchronizer} implementation that can handle text documents.
  */
-public class DefaultClientSynchronizer implements ClientSynchronizer<String, DiffMatchPatchEdit> {
+public class DiffMatchPatchClientSynchronizer implements ClientSynchronizer<String, DiffMatchPatchEdit> {
 
     private final DiffMatchPatch diffMatchPatch;
 
-    public DefaultClientSynchronizer() {
+    public DiffMatchPatchClientSynchronizer() {
         this(DiffMatchPatch.builder().build());
     }
 
-    public DefaultClientSynchronizer(final DiffMatchPatch diffMatchPatch) {
+    public DiffMatchPatchClientSynchronizer(final DiffMatchPatch diffMatchPatch) {
         this.diffMatchPatch = diffMatchPatch;
     }
 

--- a/synchronizers/diffmatchpatch/client/src/main/java/org/jboss/aerogear/sync/diffmatchpatch/client/package-info.java
+++ b/synchronizers/diffmatchpatch/client/src/main/java/org/jboss/aerogear/sync/diffmatchpatch/client/package-info.java
@@ -14,16 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
-
-import org.jboss.aerogear.sync.client.ClientSynchronizer;
-import org.jboss.aerogear.sync.server.ServerSynchronizer;
 
 /**
- * A marker interface that represents a diff or two versions of a document/object.
- * <p>
- * The actual implementation of a diff will vary depending on the type of content the the
- * {@link ClientSynchronizer} or {@link ServerSynchronizer} can handle.
+ * This package contains classes for the DiffMatchPatch synchronizer client
  */
-public interface Diff {
-}
+package org.jboss.aerogear.sync.diffmatchpatch.client;

--- a/synchronizers/diffmatchpatch/client/src/test/java/org/jboss/aerogear/sync/diffmatchpatch/client/DiffMatchPatchClientSynchronizerTest.java
+++ b/synchronizers/diffmatchpatch/client/src/test/java/org/jboss/aerogear/sync/diffmatchpatch/client/DiffMatchPatchClientSynchronizerTest.java
@@ -29,13 +29,13 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.*;
 import static org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchDiff.Operation;
 
-public class DefaultClientSynchronizerTest {
+public class DiffMatchPatchClientSynchronizerTest {
 
     private ClientSynchronizer<String, DiffMatchPatchEdit> clientSynchronizer;
 
     @Before
     public void createDocuments() {
-        clientSynchronizer = new DefaultClientSynchronizer();
+        clientSynchronizer = new DiffMatchPatchClientSynchronizer();
     }
 
     @Test

--- a/synchronizers/diffmatchpatch/core/src/main/java/org/jboss/aerogear/sync/diffmatchpatch/package-info.java
+++ b/synchronizers/diffmatchpatch/core/src/main/java/org/jboss/aerogear/sync/diffmatchpatch/package-info.java
@@ -14,16 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
-
-import org.jboss.aerogear.sync.client.ClientSynchronizer;
-import org.jboss.aerogear.sync.server.ServerSynchronizer;
 
 /**
- * A marker interface that represents a diff or two versions of a document/object.
- * <p>
- * The actual implementation of a diff will vary depending on the type of content the the
- * {@link ClientSynchronizer} or {@link ServerSynchronizer} can handle.
+ * This package contains classes for the DiffMatchPatch synchronizer core
  */
-public interface Diff {
-}
+package org.jboss.aerogear.sync.diffmatchpatch;

--- a/synchronizers/diffmatchpatch/server/src/main/java/org/jboss/aerogear/sync/diffmatchpatch/server/package-info.java
+++ b/synchronizers/diffmatchpatch/server/src/main/java/org/jboss/aerogear/sync/diffmatchpatch/server/package-info.java
@@ -14,16 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
-
-import org.jboss.aerogear.sync.client.ClientSynchronizer;
-import org.jboss.aerogear.sync.server.ServerSynchronizer;
 
 /**
- * A marker interface that represents a diff or two versions of a document/object.
- * <p>
- * The actual implementation of a diff will vary depending on the type of content the the
- * {@link ClientSynchronizer} or {@link ServerSynchronizer} can handle.
+ * This package contains classes for the DiffMatchPatch synchronizer server
  */
-public interface Diff {
-}
+package org.jboss.aerogear.sync.diffmatchpatch.server;

--- a/synchronizers/json-merge-patch/client/src/main/java/org/jboss/aerogear/sync/jsonmergepatch/client/package-info.java
+++ b/synchronizers/json-merge-patch/client/src/main/java/org/jboss/aerogear/sync/jsonmergepatch/client/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains classes for the JSON Merge Patch synchronizer client
+ */
+package org.jboss.aerogear.sync.jsonmergepatch.client;

--- a/synchronizers/json-merge-patch/core/src/main/java/org/jboss/aerogear/sync/jsonmergepatch/package-info.java
+++ b/synchronizers/json-merge-patch/core/src/main/java/org/jboss/aerogear/sync/jsonmergepatch/package-info.java
@@ -14,16 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
-
-import org.jboss.aerogear.sync.client.ClientSynchronizer;
-import org.jboss.aerogear.sync.server.ServerSynchronizer;
 
 /**
- * A marker interface that represents a diff or two versions of a document/object.
- * <p>
- * The actual implementation of a diff will vary depending on the type of content the the
- * {@link ClientSynchronizer} or {@link ServerSynchronizer} can handle.
+ * This package contains classes for the JSON Merge Patch synchronizer core
  */
-public interface Diff {
-}
+package org.jboss.aerogear.sync.jsonmergepatch;

--- a/synchronizers/json-merge-patch/server/src/main/java/org/jboss/aerogear/sync/jsonmergepatch/server/JsonMergePatchServerSynchronizer.java
+++ b/synchronizers/json-merge-patch/server/src/main/java/org/jboss/aerogear/sync/jsonmergepatch/server/JsonMergePatchServerSynchronizer.java
@@ -29,8 +29,6 @@ import org.jboss.aerogear.sync.jsonmergepatch.JsonMapper;
 import org.jboss.aerogear.sync.jsonmergepatch.JsonMergePatchEdit;
 import org.jboss.aerogear.sync.jsonmergepatch.JsonMergePatchMessage;
 import org.jboss.aerogear.sync.server.ServerSynchronizer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
 import java.nio.charset.Charset;
@@ -38,12 +36,11 @@ import java.security.MessageDigest;
 import java.util.Queue;
 
 /**
- * A {@link ServerSynchronizer} implementation that can handle text documents.
+ * A {@link ServerSynchronizer} implementation that can handle {@link JsonNode} objects.
  */
 public class JsonMergePatchServerSynchronizer implements ServerSynchronizer<JsonNode, JsonMergePatchEdit> {
 
     private static final String UTF_8 = Charset.forName("UTF-8").displayName();
-    private static final Logger logger = LoggerFactory.getLogger(JsonMergePatchServerSynchronizer.class);
 
     @Override
     public JsonMergePatchEdit clientDiff(final Document<JsonNode> document, final ShadowDocument<JsonNode> shadowDocument) {

--- a/synchronizers/json-merge-patch/server/src/main/java/org/jboss/aerogear/sync/jsonmergepatch/server/package-info.java
+++ b/synchronizers/json-merge-patch/server/src/main/java/org/jboss/aerogear/sync/jsonmergepatch/server/package-info.java
@@ -14,16 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
-
-import org.jboss.aerogear.sync.client.ClientSynchronizer;
-import org.jboss.aerogear.sync.server.ServerSynchronizer;
 
 /**
- * A marker interface that represents a diff or two versions of a document/object.
- * <p>
- * The actual implementation of a diff will vary depending on the type of content the the
- * {@link ClientSynchronizer} or {@link ServerSynchronizer} can handle.
+ * This package contains classes for the JSON Merge Patch synchronizer server
  */
-public interface Diff {
-}
+package org.jboss.aerogear.sync.jsonmergepatch.server;

--- a/synchronizers/json-patch/client/src/main/java/org/jboss/aerogear/sync/jsonpatch/client/JsonPatchClientSynchronizer.java
+++ b/synchronizers/json-patch/client/src/main/java/org/jboss/aerogear/sync/jsonpatch/client/JsonPatchClientSynchronizer.java
@@ -14,16 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
+package org.jboss.aerogear.sync.jsonpatch.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.github.fge.jsonpatch.JsonPatchException;
-import com.github.fge.jsonpatch.mergepatch.JsonMergePatch;
+import com.github.fge.jsonpatch.diff.JsonDiff;
+import org.jboss.aerogear.sync.ClientDocument;
+import org.jboss.aerogear.sync.DefaultClientDocument;
+import org.jboss.aerogear.sync.DefaultShadowDocument;
+import org.jboss.aerogear.sync.PatchMessage;
+import org.jboss.aerogear.sync.ShadowDocument;
 import org.jboss.aerogear.sync.client.ClientSynchronizer;
-import org.jboss.aerogear.sync.jsonmergepatch.JsonMapper;
-import org.jboss.aerogear.sync.jsonmergepatch.JsonMergePatchEdit;
-import org.jboss.aerogear.sync.jsonmergepatch.JsonMergePatchMessage;
+import org.jboss.aerogear.sync.jsonpatch.JsonMapper;
+import org.jboss.aerogear.sync.jsonpatch.JsonPatchEdit;
+import org.jboss.aerogear.sync.jsonpatch.JsonPatchMessage;
 import org.jboss.aerogear.sync.server.ServerSynchronizer;
 
 import java.math.BigInteger;
@@ -34,23 +38,22 @@ import java.util.Queue;
 /**
  * A {@link ServerSynchronizer} implementation that can handle text documents.
  */
-public class JsonPatchClientSynchronizer implements ClientSynchronizer<JsonNode, JsonMergePatchEdit> {
+public class JsonPatchClientSynchronizer implements ClientSynchronizer<JsonNode, JsonPatchEdit> {
 
     private static final String UTF_8 = Charset.forName("UTF-8").displayName();
 
     @Override
-    public JsonMergePatchEdit clientDiff(final ShadowDocument<JsonNode> shadowDocument, final ClientDocument<JsonNode> document) {
+    public JsonPatchEdit clientDiff(final ShadowDocument<JsonNode> shadowDocument, final ClientDocument<JsonNode> document) {
         final JsonNode shadowObject = shadowDocument.document().content();
-        return JsonMergePatchEdit.withPatch(patchFromJsonNode(document.content()))
+        return JsonPatchEdit.withPatch(JsonDiff.asJsonPatch(document.content(), shadowObject))
                 .checksum(checksum(shadowObject))
                 .build();
     }
 
-
     @Override
-    public JsonMergePatchEdit serverDiff(final ClientDocument<JsonNode> document, final ShadowDocument<JsonNode> shadowDocument) {
+    public JsonPatchEdit serverDiff(final ClientDocument<JsonNode> document, final ShadowDocument<JsonNode> shadowDocument) {
         final JsonNode shadowObject = shadowDocument.document().content();
-        return JsonMergePatchEdit.withPatch(patchFromJsonNode(shadowObject))
+        return JsonPatchEdit.withPatch(JsonDiff.asJsonPatch(shadowObject, document.content()))
                 .serverVersion(shadowDocument.serverVersion())
                 .clientVersion(shadowDocument.clientVersion())
                 .checksum(checksum(shadowObject))
@@ -58,28 +61,28 @@ public class JsonPatchClientSynchronizer implements ClientSynchronizer<JsonNode,
     }
 
     @Override
-    public ShadowDocument<JsonNode> patchShadow(final JsonMergePatchEdit edit, final ShadowDocument<JsonNode> shadowDocument) {
+    public ShadowDocument<JsonNode> patchShadow(final JsonPatchEdit edit, final ShadowDocument<JsonNode> shadowDocument) {
         final JsonNode content = patch(edit, shadowDocument.document().content());
         return new DefaultShadowDocument<JsonNode>(shadowDocument.serverVersion(), shadowDocument.clientVersion(),
                 new DefaultClientDocument<JsonNode>(shadowDocument.document().id(), shadowDocument.document().clientId(), content));
     }
 
     @Override
-    public ClientDocument<JsonNode> patchDocument(final JsonMergePatchEdit edit, final ClientDocument<JsonNode> document) {
+    public ClientDocument<JsonNode> patchDocument(final JsonPatchEdit edit, final ClientDocument<JsonNode> document) {
         final JsonNode content = patch(edit, document.content());
         return new DefaultClientDocument<JsonNode>(document.id(), document.clientId(), content);
     }
 
     @Override
-    public PatchMessage<JsonMergePatchEdit> createPatchMessage(final String documentId,
+    public PatchMessage<JsonPatchEdit> createPatchMessage(final String documentId,
                                                         final String clientId,
-                                                        final Queue<JsonMergePatchEdit> edits) {
-        return new JsonMergePatchMessage(documentId, clientId, edits);
+                                                        final Queue<JsonPatchEdit> edits) {
+        return new JsonPatchMessage(documentId, clientId, edits);
     }
 
     @Override
-    public PatchMessage<JsonMergePatchEdit> patchMessageFromJson(String json) {
-        return JsonMapper.fromJson(json, JsonMergePatchMessage.class);
+    public PatchMessage<JsonPatchEdit> patchMessageFromJson(String json) {
+        return JsonMapper.fromJson(json, JsonPatchMessage.class);
     }
 
     @Override
@@ -87,9 +90,9 @@ public class JsonPatchClientSynchronizer implements ClientSynchronizer<JsonNode,
         objectNode.put(fieldName, content);
     }
 
-    private static JsonNode patch(final JsonMergePatchEdit edit, final JsonNode target) {
+    private static JsonNode patch(final JsonPatchEdit edit, final JsonNode target) {
         try {
-            return edit.diff().jsonMergePatch().apply(target);
+            return edit.diff().jsonPatch().apply(target);
         } catch (final Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -102,14 +105,6 @@ public class JsonPatchClientSynchronizer implements ClientSynchronizer<JsonNode,
             return new BigInteger(1, md.digest()).toString(16);
         } catch (final Exception e) {
             throw new RuntimeException(e.getMessage(), e.getCause());
-        }
-    }
-
-    private static JsonMergePatch patchFromJsonNode(final JsonNode content) {
-        try {
-            return JsonMergePatch.fromJson(content);
-        } catch (final JsonPatchException e) {
-            throw new RuntimeException(e.getMessage(), e);
         }
     }
 

--- a/synchronizers/json-patch/client/src/main/java/org/jboss/aerogear/sync/jsonpatch/client/package-info.java
+++ b/synchronizers/json-patch/client/src/main/java/org/jboss/aerogear/sync/jsonpatch/client/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains classes for the JSON Patch synchronizer client
+ */
+package org.jboss.aerogear.sync.jsonpatch.client;

--- a/synchronizers/json-patch/core/src/main/java/org/jboss/aerogear/sync/jsonpatch/package-info.java
+++ b/synchronizers/json-patch/core/src/main/java/org/jboss/aerogear/sync/jsonpatch/package-info.java
@@ -14,16 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
-
-import org.jboss.aerogear.sync.client.ClientSynchronizer;
-import org.jboss.aerogear.sync.server.ServerSynchronizer;
 
 /**
- * A marker interface that represents a diff or two versions of a document/object.
- * <p>
- * The actual implementation of a diff will vary depending on the type of content the the
- * {@link ClientSynchronizer} or {@link ServerSynchronizer} can handle.
+ * This package contains classes for the JSON Patch synchronizer core
  */
-public interface Diff {
-}
+package org.jboss.aerogear.sync.jsonpatch;

--- a/synchronizers/json-patch/server/src/main/java/org/jboss/aerogear/sync/jsonpatch/server/JsonPatchServerSynchronizer.java
+++ b/synchronizers/json-patch/server/src/main/java/org/jboss/aerogear/sync/jsonpatch/server/JsonPatchServerSynchronizer.java
@@ -29,8 +29,6 @@ import org.jboss.aerogear.sync.jsonpatch.JsonMapper;
 import org.jboss.aerogear.sync.jsonpatch.JsonPatchEdit;
 import org.jboss.aerogear.sync.jsonpatch.JsonPatchMessage;
 import org.jboss.aerogear.sync.server.ServerSynchronizer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
 import java.nio.charset.Charset;
@@ -38,12 +36,11 @@ import java.security.MessageDigest;
 import java.util.Queue;
 
 /**
- * A {@link ServerSynchronizer} implementation that can handle text documents.
+ * A {@link ServerSynchronizer} implementation that can handle {@link JsonNode} objects.
  */
 public class JsonPatchServerSynchronizer implements ServerSynchronizer<JsonNode, JsonPatchEdit> {
 
     private static final String UTF_8 = Charset.forName("UTF-8").displayName();
-    private static final Logger logger = LoggerFactory.getLogger(JsonPatchServerSynchronizer.class);
 
     @Override
     public JsonPatchEdit clientDiff(final Document<JsonNode> document, final ShadowDocument<JsonNode> shadowDocument) {

--- a/synchronizers/json-patch/server/src/main/java/org/jboss/aerogear/sync/jsonpatch/server/package-info.java
+++ b/synchronizers/json-patch/server/src/main/java/org/jboss/aerogear/sync/jsonpatch/server/package-info.java
@@ -14,16 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.sync;
-
-import org.jboss.aerogear.sync.client.ClientSynchronizer;
-import org.jboss.aerogear.sync.server.ServerSynchronizer;
 
 /**
- * A marker interface that represents a diff or two versions of a document/object.
- * <p>
- * The actual implementation of a diff will vary depending on the type of content the the
- * {@link ClientSynchronizer} or {@link ServerSynchronizer} can handle.
+ * This package contains classes for the JSON Patch synchronizer server
  */
-public interface Diff {
-}
+package org.jboss.aerogear.sync.jsonpatch.server;


### PR DESCRIPTION
To test:
1) Run the following command from the root directory:
```shell
mvn clean install javadoc:aggregate
```
2) Open ```target/site/apidocs/index.html``` in a web browser and inspect the content.

JIRA: [AGSYNC-32](https://issues.jboss.org/browse/AGSYNC-32)