### PR TITLE
Renaming DiffSyncClient to SyncClient

### DIFF
--- a/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/SyncClient.java
+++ b/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/SyncClient.java
@@ -50,7 +50,7 @@ import java.util.Observer;
  * @param <T> The type of the Document that this client can handle
  * @param <S> The type of {@link Edit}s that this client can handle
  */
-public final class DiffSyncClient<T, S extends Edit<? extends Diff>> extends Observable {
+public final class SyncClient<T, S extends Edit<? extends Diff>> extends Observable {
 
     private final String host;
     private final int port;
@@ -61,7 +61,7 @@ public final class DiffSyncClient<T, S extends Edit<? extends Diff>> extends Obs
     private EventLoopGroup group;
     private Channel channel;
 
-    private DiffSyncClient(final Builder<T, S> builder) {
+    private SyncClient(final Builder<T, S> builder) {
         host = builder.host;
         port = builder.port;
         path = builder.path;
@@ -73,8 +73,8 @@ public final class DiffSyncClient<T, S extends Edit<? extends Diff>> extends Obs
         }
     }
     
-    public DiffSyncClient<T, S> connect() throws InterruptedException {
-        final DiffSyncClientHandler<T, S> diffSyncClientHandler = new DiffSyncClientHandler<T, S>(syncEngine);
+    public SyncClient<T, S> connect() throws InterruptedException {
+        final SyncClientHandler<T, S> syncClientHandler = new SyncClientHandler<T, S>(syncEngine);
         final WebSocketClientHandler handler = newWebSocketClientHandler();
         final Bootstrap b = new Bootstrap();
         group = new NioEventLoopGroup();
@@ -88,7 +88,7 @@ public final class DiffSyncClient<T, S extends Edit<? extends Diff>> extends Obs
                         new HttpObjectAggregator(8192),
                         new WebSocketClientCompressionHandler(),
                         handler,
-                        diffSyncClientHandler);
+                        syncClientHandler);
             }
         });
 
@@ -181,12 +181,12 @@ public final class DiffSyncClient<T, S extends Edit<? extends Diff>> extends Obs
             return this;
         }
         
-        public DiffSyncClient<T, S> build() {
+        public SyncClient<T, S> build() {
             if (engine == null) {
                 engine = new ClientSyncEngine(new DiffMatchPatchClientSynchronizer(), new ClientInMemoryDataStore());
             }
             uri = parseUri(this);
-            return new DiffSyncClient<T, S>(this);
+            return new SyncClient<T, S>(this);
         }
     
         private URI parseUri(final Builder<T, S> b) {

--- a/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/SyncClientHandler.java
+++ b/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/SyncClientHandler.java
@@ -39,13 +39,13 @@ import org.slf4j.LoggerFactory;
  * @param <T> The type of the Document that this handler handles
  * @param <S> The type of {@link Edit}s that this handler handles
  */
-public class DiffSyncClientHandler<T, S extends Edit<? extends Diff>> extends SimpleChannelInboundHandler<WebSocketFrame> {
+public class SyncClientHandler<T, S extends Edit<? extends Diff>> extends SimpleChannelInboundHandler<WebSocketFrame> {
 
-    private static final Logger logger = LoggerFactory.getLogger(DiffSyncClientHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(SyncClientHandler.class);
 
     private final ClientSyncEngine<T, S> syncEngine;
 
-    public DiffSyncClientHandler(final ClientSyncEngine<T, S> syncEngine) {
+    public SyncClientHandler(final ClientSyncEngine<T, S> syncEngine) {
         this.syncEngine = syncEngine;
     }
 

--- a/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/package-info.java
+++ b/client/client-netty/src/main/java/org/jboss/aerogear/sync/client/netty/package-info.java
@@ -18,6 +18,6 @@
 /**
  * This package contains Netty Client for AeroGear Sync.
  *
- * @see org.jboss.aerogear.sync.client.netty.DiffSyncClient
+ * @see org.jboss.aerogear.sync.client.netty.SyncClient
  */
 package org.jboss.aerogear.sync.client.netty;

--- a/client/client-netty/src/test/java/org/jboss/aerogear/sync/client/netty/JsonPatchClientIntegrationTest.java
+++ b/client/client-netty/src/test/java/org/jboss/aerogear/sync/client/netty/JsonPatchClientIntegrationTest.java
@@ -38,7 +38,7 @@ public class JsonPatchClientIntegrationTest {
         final JsonPatchClientSynchronizer synchronizer = new JsonPatchClientSynchronizer();
         final ClientInMemoryDataStore<JsonNode, JsonPatchEdit> dataStore = new ClientInMemoryDataStore<JsonNode, JsonPatchEdit>();
         final ClientSyncEngine<JsonNode, JsonPatchEdit> clientSyncEngine = new ClientSyncEngine<JsonNode, JsonPatchEdit>(synchronizer, dataStore);
-        final DiffSyncClient<JsonNode, JsonPatchEdit> client = DiffSyncClient.<JsonNode, JsonPatchEdit>forHost("localhost")
+        final SyncClient<JsonNode, JsonPatchEdit> client = SyncClient.<JsonNode, JsonPatchEdit>forHost("localhost")
                 .syncEngine(clientSyncEngine)
                 .port(7777)
                 .path("/sync")

--- a/client/client-netty/src/test/java/org/jboss/aerogear/sync/client/netty/SyncClientIntegrationTest.java
+++ b/client/client-netty/src/test/java/org/jboss/aerogear/sync/client/netty/SyncClientIntegrationTest.java
@@ -19,10 +19,9 @@ package org.jboss.aerogear.sync.client.netty;
 import org.jboss.aerogear.sync.ClientDocument;
 import org.jboss.aerogear.sync.DefaultClientDocument;
 import org.jboss.aerogear.sync.diffmatchpatch.DiffMatchPatchEdit;
-import org.jboss.aerogear.sync.client.netty.DiffSyncClient;
 import org.junit.Test;
 
-public class DiffSyncClientIntegrationTest {
+public class SyncClientIntegrationTest {
     
     @Test
     public void connect() throws InterruptedException {
@@ -30,7 +29,7 @@ public class DiffSyncClientIntegrationTest {
         final String clientId = "client2";
         final String originalVersion = "{\"id\": 9999}";
         
-        final DiffSyncClient<String, DiffMatchPatchEdit> client = DiffSyncClient.<String, DiffMatchPatchEdit>forHost("localhost").port(7777).path("/sync").build();
+        final SyncClient<String, DiffMatchPatchEdit> client = SyncClient.<String, DiffMatchPatchEdit>forHost("localhost").port(7777).path("/sync").build();
         client.connect();
         client.addDocument(clientDoc(documentId, clientId, originalVersion));
         Thread.sleep(1000);


### PR DESCRIPTION
Motivation:
The Netty client is currently named DiffSyncClient whereas the iOS
client is named SyncClient.
To be consistent both should have the same name and SyncClient is easier
on the eyes.

Jira:
https://issues.jboss.org/browse/AGSYNC-43