### PR TITLE
Adding in a very VERY basic wildfly module

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -6,6 +6,9 @@ Contains the ServerSyncEngine and an in-memory server data store implementation.
 * [server-netty](./server-netty)  
 Contains a Netty server that uses the [server-engine](./server-engine).
 
+* [server-wildfly](./server-wildfly)  
+Contains a WildFly server that uses the [server-engine](./server-engine).
+
 * [server-xmpp](./server-xmpp)  
 Contains a Google Cloud Messaging XMPP implmentation that is used by the [server-netty](./server-netty) module.
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -32,6 +32,7 @@
         <module>server-engine</module>
         <module>server-netty</module>
         <module>server-xmpp</module>
+        <module>server-wildfly</module>
     </modules>
 
 </project>

--- a/server/server-wildfly/pom.xml
+++ b/server/server-wildfly/pom.xml
@@ -90,5 +90,12 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>jboss-repo</id>
+            <name>jboss-repo</name>
+            <url>https://repository.jboss.org</url>
+        </repository>
+    </repositories>
 </project>
 

--- a/server/server-wildfly/pom.xml
+++ b/server/server-wildfly/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0"?>
+<!--
+  JBoss, Home of Professional Open Source
+  Copyright Red Hat, Inc., and individual contributors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.aerogear</groupId>
+        <artifactId>sync-server-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>sync-server-wildfly</artifactId>
+    <packaging>war</packaging>
+    <name>AeroGear Data Synchronization Server Wildfly</name>
+
+    <properties>
+        <jboss-annotations-ejb3-version>4.2.3.GA</jboss-annotations-ejb3-version>
+        <java-ee-version>7.0</java-ee-version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>jboss</groupId>
+            <artifactId>jboss-annotations-ejb3</artifactId>
+            <version>${jboss-annotations-ejb3-version}</version>
+            <scope>provided</scope>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-web-api</artifactId>
+            <version>${java-ee-version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>sync-server-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>sync-diffmatchpatch-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>sync-json-patch-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>sync-server-xmpp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>sync-json-merge-patch-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>sync-client-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>sync-diffmatchpatch-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>1.0.2.Final</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/server/server-wildfly/pom.xml
+++ b/server/server-wildfly/pom.xml
@@ -33,13 +33,6 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>jboss</groupId>
-            <artifactId>jboss-annotations-ejb3</artifactId>
-            <version>${jboss-annotations-ejb3-version}</version>
-            <scope>provided</scope>
-            <type>jar</type>
-        </dependency>
-        <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-web-api</artifactId>
             <version>${java-ee-version}</version>

--- a/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/LoggingSendHandler.java
+++ b/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/LoggingSendHandler.java
@@ -21,6 +21,10 @@ import java.util.logging.Logger;
 import javax.websocket.SendHandler;
 import javax.websocket.SendResult;
 
+/**
+ * An implementation of the SendHandler callback object that logs any errors that occured after the websocket message 
+ * has been transmitted.
+ */ 
 public class LoggingSendHandler implements SendHandler{
     public final static SendHandler INSTANCE = new LoggingSendHandler();
 
@@ -33,5 +37,4 @@ public class LoggingSendHandler implements SendHandler{
             Logger.getAnonymousLogger().log(Level.SEVERE, error.getMessage(), error);
         }
     }
-    
 }

--- a/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/LoggingSendHandler.java
+++ b/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/LoggingSendHandler.java
@@ -1,0 +1,37 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.sync.server.wildfly;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.websocket.SendHandler;
+import javax.websocket.SendResult;
+
+public class LoggingSendHandler implements SendHandler{
+    public final static SendHandler INSTANCE = new LoggingSendHandler();
+
+    private LoggingSendHandler(){}
+    
+    @Override
+    public void onResult(SendResult result) {
+        if (!result.isOK()) {
+            Throwable error = result.getException();
+            Logger.getAnonymousLogger().log(Level.SEVERE, error.getMessage(), error);
+        }
+    }
+    
+}

--- a/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/SyncEndpoint.java
+++ b/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/SyncEndpoint.java
@@ -1,0 +1,107 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.sync.server.wildfly;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.logging.Logger;
+import javax.websocket.*;
+import javax.websocket.server.ServerEndpoint;
+import org.jboss.aerogear.sync.Document;
+import org.jboss.aerogear.sync.PatchMessage;
+import org.jboss.aerogear.sync.diffmatchpatch.JsonMapper;
+import org.jboss.aerogear.sync.jsonpatch.JsonPatchEdit;
+import org.jboss.aerogear.sync.jsonpatch.server.JsonPatchServerSynchronizer;
+import org.jboss.aerogear.sync.server.MessageType;
+import org.jboss.aerogear.sync.server.ServerInMemoryDataStore;
+import org.jboss.aerogear.sync.server.ServerSyncEngine;
+import org.jboss.aerogear.sync.server.Subscriber;
+
+@ServerEndpoint("/sync")
+public class SyncEndpoint {
+
+    private static final JsonPatchServerSynchronizer synchronizer = new JsonPatchServerSynchronizer();
+    private static final ServerInMemoryDataStore<JsonNode, JsonPatchEdit> dataStore = new ServerInMemoryDataStore<JsonNode, JsonPatchEdit>();
+    private static final ServerSyncEngine<JsonNode, JsonPatchEdit> syncEngine = new ServerSyncEngine<JsonNode, JsonPatchEdit>(synchronizer, dataStore);
+    private static final String DOC_ADD = "DOC_ADD";
+    private static final String WILDFLY_SUBSCRIBER = "WILDFLY_SUBSCRIBER";
+    private static final Logger logger = Logger.getLogger(SyncEndpoint.class.getSimpleName());
+    private static final String DOCUMENT_ID = "DOCUMENT_ID";
+    
+    @OnMessage
+    public String onMessage(String message, Session webSocketSession) {
+        final JsonNode json = JsonMapper.asJsonNode(message);
+
+        switch (MessageType.from(json.get("msgType").asText())) {
+            case ADD:
+                final Document<JsonNode> doc = syncEngine.documentFromJson(json);
+                final String clientId = json.get("clientId").asText();
+                final PatchMessage<JsonPatchEdit> patchMessage = addSubscriber(doc, clientId, webSocketSession);
+                webSocketSession.getUserProperties().put(DOC_ADD, true);
+                return (patchMessage.asJson());
+
+            case PATCH:
+                final PatchMessage<JsonPatchEdit> clientPatchMessage = syncEngine.patchMessageFromJson(json.toString());
+                checkForReconnect(clientPatchMessage.documentId(), clientPatchMessage.clientId(), webSocketSession);
+                patch(clientPatchMessage);
+                break;
+            case DETACH:
+                // detach the client from a specific document.
+                break;
+            case UNKNOWN:
+                return "{\"result\": \"Unknown msgType '" + json.get("msgType").asText() + "'\"}";
+        
+        }
+        
+        return message;
+    }
+
+    @OnOpen
+    public void myOnOpen(Session session) {
+        System.out.println("WebSocket opened: " + session.getId());
+    }
+
+    @OnClose
+    public void myOnClose(CloseReason reason, Session webSocketSession) {
+        System.out.println("Closing a WebSocket due to " + reason.getReasonPhrase());
+        WildflySubscriber subscriber = (WildflySubscriber) webSocketSession.getUserProperties().get(WILDFLY_SUBSCRIBER);
+        String documentId = (String) webSocketSession.getUserProperties().get(DOCUMENT_ID);
+        syncEngine.removeSubscriber(subscriber, documentId);
+
+    }
+
+    private PatchMessage<JsonPatchEdit> addSubscriber(final Document<JsonNode> document,
+            final String clientId, Session session) {
+        final Subscriber<Session> subscriber = new WildflySubscriber(clientId, session);
+        return syncEngine.addSubscriber(subscriber, document);
+    }
+
+    private void patch(final PatchMessage<JsonPatchEdit> patchMessage) {
+        syncEngine.notifySubscribers(syncEngine.patch(patchMessage));
+    }
+
+    private void checkForReconnect(final String documentId, final String clientId, final Session session) {
+        if (session.getUserProperties().getOrDefault(DOC_ADD, Boolean.FALSE) == Boolean.TRUE) {
+            return;
+        }
+        logger.info("Reconnected client [" + clientId + "]. Adding as listener.");
+
+        final WildflySubscriber subscriber = new WildflySubscriber(clientId, session);
+        syncEngine.connectSubscriber(subscriber, documentId);
+        
+    }
+
+}

--- a/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/SyncEndpoint.java
+++ b/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/SyncEndpoint.java
@@ -17,6 +17,8 @@
 package org.jboss.aerogear.sync.server.wildfly;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Map;
 import java.util.logging.Logger;
 import javax.websocket.CloseReason;
 import javax.websocket.OnMessage;
@@ -98,14 +100,18 @@ public class SyncEndpoint {
     }
 
     private void checkForReconnect(final String documentId, final String clientId, final Session session) {
-        if (session.getUserProperties().getOrDefault(DOC_ADD, Boolean.FALSE) == Boolean.TRUE) {
+        if (getOrDefault(session.getUserProperties(),Boolean.FALSE) == Boolean.TRUE) {
             return;
         }
         logger.info("Reconnected client [" + clientId + "]. Adding as listener.");
 
         final WildflySubscriber subscriber = new WildflySubscriber(clientId, session);
         syncEngine.connectSubscriber(subscriber, documentId);
-        
+    }
+
+    private static Boolean getOrDefault(final Map<String, Object> properties, final Boolean defaultValue) {
+        final Boolean value = (Boolean) properties.get(DOC_ADD);
+        return value != null ? value : defaultValue;
     }
 
 }

--- a/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/SyncEndpoint.java
+++ b/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/SyncEndpoint.java
@@ -18,7 +18,11 @@ package org.jboss.aerogear.sync.server.wildfly;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.logging.Logger;
-import javax.websocket.*;
+import javax.websocket.CloseReason;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.OnClose;
+import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
 import org.jboss.aerogear.sync.Document;
 import org.jboss.aerogear.sync.PatchMessage;
@@ -70,13 +74,13 @@ public class SyncEndpoint {
     }
 
     @OnOpen
-    public void myOnOpen(Session session) {
-        System.out.println("WebSocket opened: " + session.getId());
+    public void onOpen(Session session) {
+        logger.info("WebSocket opened: " + session.getId());
     }
 
     @OnClose
-    public void myOnClose(CloseReason reason, Session webSocketSession) {
-        System.out.println("Closing a WebSocket due to " + reason.getReasonPhrase());
+    public void onClose(CloseReason reason, Session webSocketSession) {
+        logger.info("Closing a WebSocket due to " + reason.getReasonPhrase());
         WildflySubscriber subscriber = (WildflySubscriber) webSocketSession.getUserProperties().get(WILDFLY_SUBSCRIBER);
         String documentId = (String) webSocketSession.getUserProperties().get(DOCUMENT_ID);
         syncEngine.removeSubscriber(subscriber, documentId);
@@ -84,7 +88,7 @@ public class SyncEndpoint {
     }
 
     private PatchMessage<JsonPatchEdit> addSubscriber(final Document<JsonNode> document,
-            final String clientId, Session session) {
+        final String clientId, Session session) {
         final Subscriber<Session> subscriber = new WildflySubscriber(clientId, session);
         return syncEngine.addSubscriber(subscriber, document);
     }

--- a/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/WildflySubscriber.java
+++ b/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/WildflySubscriber.java
@@ -48,5 +48,28 @@ public class WildflySubscriber implements Subscriber<Session> {
             webSocketSession.getAsyncRemote().sendText(patchMessage.asJson(), LoggingSendHandler.INSTANCE);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        @SuppressWarnings("unchecked")
+        final Subscriber<Session> subscriber = (Subscriber<Session>) o;
+        if (!clientId.equals(subscriber.clientId())) {
+            return false;
+        }
+        return !webSocketSession.equals(subscriber.channel());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = clientId.hashCode();
+        result = 31 * result + webSocketSession.hashCode();
+        return result;
+    }
     
 }

--- a/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/WildflySubscriber.java
+++ b/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/WildflySubscriber.java
@@ -20,7 +20,9 @@ import javax.websocket.Session;
 import org.jboss.aerogear.sync.PatchMessage;
 import org.jboss.aerogear.sync.server.Subscriber;
 
-
+/**
+ * Represents a subscriber of patches for the WebSocket Session type.
+ */
 public class WildflySubscriber implements Subscriber<Session> {
     private final Session webSocketSession;
     private final String clientId;

--- a/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/WildflySubscriber.java
+++ b/server/server-wildfly/src/main/java/org/jboss/aerogear/sync/server/wildfly/WildflySubscriber.java
@@ -1,0 +1,50 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.sync.server.wildfly;
+
+import javax.websocket.Session;
+import org.jboss.aerogear.sync.PatchMessage;
+import org.jboss.aerogear.sync.server.Subscriber;
+
+
+public class WildflySubscriber implements Subscriber<Session> {
+    private final Session webSocketSession;
+    private final String clientId;
+
+    public WildflySubscriber(String clientId, Session webSocketSession) {
+        this.clientId = clientId;
+        this.webSocketSession = webSocketSession;
+    }
+
+    @Override
+    public String clientId() {
+        return clientId;
+    }
+
+    @Override
+    public Session channel() {
+        return webSocketSession;
+    }
+
+    @Override
+    public void patched(PatchMessage<?> patchMessage) {
+        if (webSocketSession.isOpen()) {
+            webSocketSession.getAsyncRemote().sendText(patchMessage.asJson(), LoggingSendHandler.INSTANCE);
+        }
+    }
+    
+}

--- a/server/server-wildfly/src/main/webapp/WEB-INF/beans.xml
+++ b/server/server-wildfly/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source
+    Copyright Red Hat, Inc., and individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    	http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="annotated">
+</beans>

--- a/server/server-wildfly/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/server/server-wildfly/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web>
+  <context-root>/</context-root>
+</jboss-web>
+

--- a/server/server-wildfly/src/main/webapp/WEB-INF/web.xml
+++ b/server/server-wildfly/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source
+    Copyright Red Hat, Inc., and individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    	http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+    <session-config>
+        <session-timeout>
+            30
+        </session-timeout>
+    </session-config>
+
+</web-app>


### PR DESCRIPTION
I've created a new sync server module for wildfly.  This is VERY preliminary but proves the sync server is compatible with JSR 356. More importantly this means that we can leverage annotations to add in simple security.  Hello keycloak secured sync servers!  (Eventually)

How to test:

```
# From Project root
mvn clean install;
cd server/server-wildfly;
mvn wildfly:run;
```

The build should run without error and the server should start up.

From any of the demos use the following:    
**server host** : localhost  
**server port** : 8080  
**sync path** : /sync-server-wildfly-0.0.1-SNAPSHOT/sync  

It should work as if you were running the netty service.
