### PR TITLE
small readme polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,6 @@ Contains tests that use both the [server-engine](./server/server-engine) and [cl
 
     mvn clean install
 
-### Creating a distribution
-A distribution (a "fat" jar) can be produces by running the following maven command from the [distribution](./distribution)
-directory:
-
-    mvn package
-
-This willl produce a ```target/aerogear-sync-server-VERSION.jar``` file. This jar is executable and can be used to start
-the JSON Patch server:
-
-    java -jar target/aerogear-sync-server-VERSION.jar
-
 ## Usage
 
 ### Starting the JSON Patch server

--- a/server/server-netty/README.md
+++ b/server/server-netty/README.md
@@ -15,7 +15,7 @@ that uses [DiffMatchPatch](../../synchronizers/diffmatchpatch) for diffs/patches
 
 #### Executable JAR file
 
-Alternative we also create an executalbe JAR file, using the Maven Shade plugin. Build the JAR
+Alternatively, you can also create an executable JAR file using the Maven Shade plug-in. Build the JAR:
 
     mvn clean install -Pdiffmatch
 
@@ -33,7 +33,7 @@ server implementation that uses [JSON Patch](../..//synchronizers/json-patch) fo
 
 #### Executable JAR file
 
-Alternative we also create an executalbe JAR file, using the Maven Shade plugin. Build the JAR
+Alternatively, you can also create an executable JAR file using the Maven Shade plug-in. Build the JAR:
 
     mvn clean install -Pjsonpatch
 
@@ -51,7 +51,7 @@ server implementation that uses [JSON Merge Patch](../../synchronizers/json-merg
 
 #### Executable JAR file
 
-Alternative we also create an executalbe JAR file, using the Maven Shade plugin. Build the JAR
+Alternatively, you can also create an executable JAR file using the Maven Shade plugin. Build the JAR:
 
     mvn clean install -Pjsonmerge
 


### PR DESCRIPTION
- removed "Creating a distribution' section" on top-level README.md, since ```target/aerogear-sync-server-VERSION.jar``` didn't exist after ```mvn package``` in top-level
- typo syntax polish on /server-netty README.md

